### PR TITLE
Reproduce error

### DIFF
--- a/crosschain-resolver/test/testResolver.ts
+++ b/crosschain-resolver/test/testResolver.ts
@@ -99,9 +99,9 @@ describe('Crosschain Resolver', () => {
     expect(result2).to.equal(addr);
   })
 
-  it("should test ETH Address", async() => {
+  it.only("should test ETH Address", async() => {
     const addr = '0x5A384227B65FA093DEC03Ec34e111Db80A040615'
-    await l2contract.clearRecords(node)
+    // await l2contract.clearRecords(node)
     await l2contract['setAddr(bytes32,address)'](node, addr)
     const result = await l2contract['addr(bytes32)'](node)
     expect(ethers.getAddress(result)).to.equal(addr);

--- a/evm-gateway/src/EVMGateway.ts
+++ b/evm-gateway/src/EVMGateway.ts
@@ -6,6 +6,7 @@ import {
   getBytes,
   solidityPackedKeccak256,
   toBigInt,
+  zeroPadValue,
 } from 'ethers';
 
 import type { IProofService, ProvableBlock } from './IProofService.js';
@@ -246,8 +247,11 @@ export class EVMGateway<T extends ProvableBlock> {
       return {
         slots: [slot],
         isDynamic,
-        value: memoize(() =>
-          this.proofService.getStorageAt(block, address, slot)
+        value: memoize(async () =>
+          zeroPadValue(
+            await this.proofService.getStorageAt(block, address, slot),
+            32
+          )
         ),
       };
     } else {

--- a/l1-verifier/contracts/test/TestL1.sol
+++ b/l1-verifier/contracts/test/TestL1.sol
@@ -103,4 +103,16 @@ contract TestL1 is EVMFetchTarget {
     function getZeroCallback(bytes[] memory values, bytes memory) public pure returns (uint256) {
         return abi.decode(values[0], (uint256));
     }
+
+    function getZeroIndex() public view returns(uint256) {
+        EVMFetcher.newFetchRequest(verifier, target)
+            .getStatic(5)
+            .getStatic(2)
+                .ref(0)
+            .fetch(this.getZeroIndexCallback.selector, "");
+    }
+
+    function getZeroIndexCallback(bytes[] memory values, bytes memory) public pure returns(uint256) {
+        return abi.decode(values[1], (uint256));
+    }
 }

--- a/l1-verifier/contracts/test/TestL2.sol
+++ b/l1-verifier/contracts/test/TestL2.sol
@@ -12,6 +12,7 @@ contract TestL2 {
     constructor() {
         latest = 42;
         name = "Satoshi";
+        highscores[0] = 1;
         highscores[latest] = 12345;
         highscorers[latest] = "Hal Finney";
         highscorers[1] = "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff Sr.";

--- a/l1-verifier/test/testL1Verifier.ts
+++ b/l1-verifier/test/testL1Verifier.ts
@@ -136,4 +136,9 @@ describe('L1Verifier', () => {
     const result = await target.getNickname('Santa', { enableCcipRead: true });
     expect(result).to.equal('');
   });
+
+  it('will index on uninitialized values', async () => {
+    const result = await target.getZeroIndex({ enableCcipRead: true });
+    expect(Number(result)).to.equal(1);
+  })
 });


### PR DESCRIPTION

This change now causes proof error

```
  1) Crosschain Resolver
       should test ETH Address:
     Error: execution reverted: "MerkleTrie: provided proof is invalid" (action="call", data="0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000254d65726b6c65547269653a2070726f76696465642070726f6f6620697320696e76616c6964000000000000000000000000000000000000000000000000000000", reason="MerkleTrie: provided proof is invalid", transaction={ "data": "0x3b3b57de80ee077a908dffcf32972ba13c2df16b42688e1de21bcf17d3469a8507895eae", "to": "0x5095E8F2f0Af84c8D49122aa4488AdA7422211F1" }, invocation=null, revert={ "args": [ "MerkleTrie: provided proof is invalid" ], "name": "Error", "signature": "Error(string)" }, code=CALL_EXCEPTION, version=6.8.0)
      at makeError (/Users/makoto/work/ens/tmp/evmgateway/node_modules/ethers/src.ts/utils/errors.ts:694:21)
      at getBuiltinCallException (/Users/makoto/work/ens/tmp/evmgateway/node_modules/ethers/src.ts/abi/abi-coder.ts:118:21)
      at Function.getBuiltinCallException (/Users/makoto/work/ens/tmp/evmgateway/node_modules/ethers/src.ts/abi/abi-coder.ts:230:16)
      at Interface.makeError (/Users/makoto/work/ens/tmp/evmgateway/node_modules/ethers/src.ts/abi/interface.ts:925:32)
      at staticCallResult (/Users/makoto/work/ens/tmp/evmgateway/node_modules/ethers/src.ts/contract/contract.ts:340:42)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async staticCall (/Users/makoto/work/ens/tmp/evmgateway/node_modules/ethers/src.ts/contract/contract.ts:303:24)
      at async Proxy.addr (/Users/makoto/work/ens/tmp/evmgateway/node_modules/ethers/src.ts/contract/contract.ts:351:41)
      at async Context.<anonymous> (test/testResolver.ts:109:21)


```