### PR TITLE
Add Sepolia verifier contracts and gateway deployment details

### DIFF
--- a/arb-gateway/wrangler.toml
+++ b/arb-gateway/wrangler.toml
@@ -1,8 +1,9 @@
-name = "arb-sepolia-gateway-worker"
+name = "arb-gateway-worker"
 account_id = "15dcc9085cb794bb4f29d3e8177ac880"
 main = "./src/worker.ts"
 node_compat = true
 compatibility_date = "2023-10-13"
+
 
 [dev]
 port = 8080
@@ -10,4 +11,5 @@ port = 8080
 [build]
 command = "yarn build"
 
-[vars]
+[env.sepolia]
+name = "arb-sepolia-gateway-worker"

--- a/arb-gateway/wrangler.toml
+++ b/arb-gateway/wrangler.toml
@@ -1,4 +1,4 @@
-name = "arb-gateway-worker"
+name = "arb-sepolia-gateway-worker"
 account_id = "15dcc9085cb794bb4f29d3e8177ac880"
 main = "./src/worker.ts"
 node_compat = true

--- a/arb-verifier/README.md
+++ b/arb-verifier/README.md
@@ -46,17 +46,38 @@ bun run test
 
 ## Deployments
 
-### L2
+#### Goerli
+
+##### L2
 
 - TestL2.sol = [0xAdef74372444e716C0473dEe1F9Cb3108EFa3818](https://goerli.arbiscan.io/address/0xAdef74372444e716C0473dEe1F9Cb3108EFa3818#code)
 
-### L1
+##### L1
 
 - ArbVerifier = [0x9E46DeE08Ad370bEFa7858c0E9a6c87f2D7E57A1](https://goerli.etherscan.io/address/0x9E46DeE08Ad370bEFa7858c0E9a6c87f2D7E57A1#code)
 
 - TestL1.sol = [0x0d6c6B70cd561EB59e6818D832197fFad60840AB](https://goerli.etherscan.io/address/0x0d6c6B70cd561EB59e6818D832197fFad60840AB#code)
 
-### Gateway server
+##### Gateway server
 
 - https://arb-gateway-worker.ens-cf.workers.dev
 
+
+#### Sepolia
+
+##### L2
+
+- TestL2.sol = [0x162A433068F51e18b7d13932F27e66a3f99E6890](https://api-sepolia.arbiscan.io/address/0x162A433068F51e18b7d13932F27e66a3f99E6890#code)
+
+##### L1
+
+- ArbVerifier = [0x6820E47CED34D6F275c6d26C3876D48B2c1fdf27](https://sepolia.etherscan.io/address/0x6820E47CED34D6F275c6d26C3876D48B2c1fdf27#code)
+- TestL1.sol = [0x50200c7Ccb1abD927184396547ea8dD1A18CAA3A](https://sepolia.etherscan.io/address/0x50200c7Ccb1abD927184396547ea8dD1A18CAA3A#code)
+
+deploying "ArbVerifier" (tx: 0x61ae88749f911f1e09d7c073f34a13bb843c71fafaf93a1266423798bd3aadc6)...: deployed at 0x6820E47CED34D6F275c6d26C3876D48B2c1fdf27 with 3872186 gas
+deploying "TestL1" (tx: 0x0a7b6b74357d20f33cb89df12da3db34b5cd3c764403888420108ca13f0126fa)...: deployed at 0x50200c7Ccb1abD927184396547ea8dD1A18CAA3A with 2411152 gas
+
+
+##### Gateway server
+
+- https://arb-sepolia-gateway-worker.ens-cf.workers.dev

--- a/arb-verifier/README.md
+++ b/arb-verifier/README.md
@@ -46,30 +46,30 @@ bun run test
 
 ## Deployments
 
-#### Goerli
+### Goerli
 
-##### L2
+#### L2
 
 - TestL2.sol = [0xAdef74372444e716C0473dEe1F9Cb3108EFa3818](https://goerli.arbiscan.io/address/0xAdef74372444e716C0473dEe1F9Cb3108EFa3818#code)
 
-##### L1
+#### L1
 
 - ArbVerifier = [0x9E46DeE08Ad370bEFa7858c0E9a6c87f2D7E57A1](https://goerli.etherscan.io/address/0x9E46DeE08Ad370bEFa7858c0E9a6c87f2D7E57A1#code)
 
 - TestL1.sol = [0x0d6c6B70cd561EB59e6818D832197fFad60840AB](https://goerli.etherscan.io/address/0x0d6c6B70cd561EB59e6818D832197fFad60840AB#code)
 
-##### Gateway server
+#### Gateway server
 
 - https://arb-gateway-worker.ens-cf.workers.dev
 
 
-#### Sepolia
+### Sepolia
 
-##### L2
+#### L2
 
 - TestL2.sol = [0x162A433068F51e18b7d13932F27e66a3f99E6890](https://api-sepolia.arbiscan.io/address/0x162A433068F51e18b7d13932F27e66a3f99E6890#code)
 
-##### L1
+#### L1
 
 - ArbVerifier = [0x6820E47CED34D6F275c6d26C3876D48B2c1fdf27](https://sepolia.etherscan.io/address/0x6820E47CED34D6F275c6d26C3876D48B2c1fdf27#code)
 - TestL1.sol = [0x50200c7Ccb1abD927184396547ea8dD1A18CAA3A](https://sepolia.etherscan.io/address/0x50200c7Ccb1abD927184396547ea8dD1A18CAA3A#code)
@@ -77,7 +77,12 @@ bun run test
 deploying "ArbVerifier" (tx: 0x61ae88749f911f1e09d7c073f34a13bb843c71fafaf93a1266423798bd3aadc6)...: deployed at 0x6820E47CED34D6F275c6d26C3876D48B2c1fdf27 with 3872186 gas
 deploying "TestL1" (tx: 0x0a7b6b74357d20f33cb89df12da3db34b5cd3c764403888420108ca13f0126fa)...: deployed at 0x50200c7Ccb1abD927184396547ea8dD1A18CAA3A with 2411152 gas
 
-
-##### Gateway server
+#### Gateway url
 
 - https://arb-sepolia-gateway-worker.ens-cf.workers.dev
+
+## Testing gateway
+
+```
+TARGET_ADDRESS=$TEST_L1_ADDRESS PROVIDER_URL=$L1_PROVIDER_URL npx hardhat run ../l1-verifier/scripts/remote.ts --network sepolia
+```

--- a/arb-verifier/arguments.js
+++ b/arb-verifier/arguments.js
@@ -1,0 +1,6 @@
+module.exports = [
+  [
+    'https://arb-sepolia-gateway-worker.ens-cf.workers.dev/{sender}/{data}.json'
+  ],
+  '0xd80810638dbDF9081b72C1B33c65375e807281C8'
+];

--- a/arb-verifier/deploy_l1/00_arb_verifier.ts
+++ b/arb-verifier/deploy_l1/00_arb_verifier.ts
@@ -5,10 +5,12 @@ import 'dotenv/config';
 const GATEWAY_URLS = {
   arbDevnetL1: 'http://localhost:8089/{sender}/{data}.json',
   goerli: 'https://arb-gateway-worker.ens-cf.workers.dev/{sender}/{data}.json',
+  sepolia: 'https://arb-sepolia-gateway-worker.ens-cf.workers.dev/{sender}/{data}.json',
 };
 
 const ROLLUP_ADDRESSES = {
   goerli: '0x45e5cAea8768F42B385A366D3551Ad1e0cbFAb17',
+  sepolia: '0xd80810638dbDF9081b72C1B33c65375e807281C8',
 };
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {

--- a/arb-verifier/hardhat.config.ts
+++ b/arb-verifier/hardhat.config.ts
@@ -9,7 +9,7 @@ const DEPLOYER_PRIVATE_KEY =
 const L1_PROVIDER_URL = process.env.L1_PROVIDER_URL || '';
 const L1_ETHERSCAN_API_KEY = process.env.L1_ETHERSCAN_API_KEY;
 const L2_ETHERSCAN_API_KEY = process.env.L2_ETHERSCAN_API_KEY;
-console.log({DEPLOYER_PRIVATE_KEY})
+
 const config: HardhatUserConfig = {
   solidity: '0.8.19',
   networks: {

--- a/arb-verifier/hardhat.config.ts
+++ b/arb-verifier/hardhat.config.ts
@@ -9,7 +9,7 @@ const DEPLOYER_PRIVATE_KEY =
 const L1_PROVIDER_URL = process.env.L1_PROVIDER_URL || '';
 const L1_ETHERSCAN_API_KEY = process.env.L1_ETHERSCAN_API_KEY;
 const L2_ETHERSCAN_API_KEY = process.env.L2_ETHERSCAN_API_KEY;
-
+console.log({DEPLOYER_PRIVATE_KEY})
 const config: HardhatUserConfig = {
   solidity: '0.8.19',
   networks: {
@@ -38,16 +38,31 @@ const config: HardhatUserConfig = {
         l2: 'arbitrumGoerli',
       },
     },
+    sepolia: {
+      url: L1_PROVIDER_URL,
+      accounts: [DEPLOYER_PRIVATE_KEY],
+      deploy: ['deploy_l1/'],
+      companionNetworks: {
+        l2: 'arbitrumSepolia',
+      },
+    },
     arbitrumGoerli: {
       url: 'https://rpc.goerli.arbitrum.gateway.fm',
       accounts: [DEPLOYER_PRIVATE_KEY],
       deploy: ['deploy_l2/'],
     },
+    arbitrumSepolia: {
+      url: 'https://sepolia-rollup.arbitrum.io/rpc',
+      accounts: [DEPLOYER_PRIVATE_KEY],
+      deploy: [ "deploy_l2/" ],
+    },
   },
   etherscan: {
     apiKey: {
       goerli: L1_ETHERSCAN_API_KEY,
+      sepolia: L1_ETHERSCAN_API_KEY,
       arbitrumGoerli: L2_ETHERSCAN_API_KEY,
+      arbitrumSepolia: L2_ETHERSCAN_API_KEY,
     },
     customChains: [
       {
@@ -55,9 +70,17 @@ const config: HardhatUserConfig = {
         chainId: 421613,
         urls: {
           apiURL: 'https://api-goerli.arbiscan.io/api',
-          browserURL: 'https://api-goerli.arbiscan.io.io',
+          browserURL: 'https://api-goerli.arbiscan.io',
         },
       },
+      {
+        network: "arbitrumSepolia",
+        chainId: 421614,
+        urls: {
+          apiURL: "https://api-sepolia.arbiscan.io/api",
+          browserURL: "https://api-sepolia.arbiscan.io"
+        }
+      }
     ],
   },
   namedAccounts: {

--- a/op-gateway/README.md
+++ b/op-gateway/README.md
@@ -25,7 +25,7 @@ wrangler secret put L1_PROVIDER_URL
 wrangler secret put L2_PROVIDER_URL
 wrangler secret put L2_OUTPUT_ORACLE
 wrangler secret put DELAY
-yarn deploy
+yarn deploy --env op-sepolia // or --env base-sepolia for base deployment
 ```
 
 ## How to test

--- a/op-gateway/wrangler.toml
+++ b/op-gateway/wrangler.toml
@@ -1,4 +1,4 @@
-name = "op-gateway-worker"
+name = "op-sepolia-gateway-worker"
 account_id = "15dcc9085cb794bb4f29d3e8177ac880"
 main = "./src/worker.ts"
 node_compat = true

--- a/op-gateway/wrangler.toml
+++ b/op-gateway/wrangler.toml
@@ -1,4 +1,3 @@
-name = "base-sepolia-gateway-worker"
 account_id = "15dcc9085cb794bb4f29d3e8177ac880"
 main = "./src/worker.ts"
 node_compat = true
@@ -10,4 +9,8 @@ port = 8080
 [build]
 command = "yarn build"
 
-[vars]
+[env.base-sepolia]
+name = "base-sepolia-gateway-worker"
+
+[env.op-sepolia]
+name = "op-sepolia-gateway-worker"

--- a/op-gateway/wrangler.toml
+++ b/op-gateway/wrangler.toml
@@ -1,4 +1,4 @@
-name = "op-sepolia-gateway-worker"
+name = "base-sepolia-gateway-worker"
 account_id = "15dcc9085cb794bb4f29d3e8177ac880"
 main = "./src/worker.ts"
 node_compat = true

--- a/op-verifier/README.md
+++ b/op-verifier/README.md
@@ -51,10 +51,17 @@ The tests will require small modifications to work on public testnets; specifica
 
 #### L1
 
+- OPVerifier = [0xAdef74372444e716C0473dEe1F9Cb3108EFa3818](https://sepolia.etherscan.io/address/0xAdef74372444e716C0473dEe1F9Cb3108EFa3818#code
+)
+- TestL1 = [0x540C93800699C044dB8cf1f0F059ca0FA5CaED92](https://sepolia.etherscan.io/address/0x540C93800699C044dB8cf1f0F059ca0FA5CaED92#code)
+
 #### L2
 
 - TestL2 = [0x94fbCE7ca1a0152cfC99F90f4421d31cf356c896](https://sepolia.basescan.org/address/0x94fbCE7ca1a0152cfC99F90f4421d31cf356c896#code)
 
+#### Gateway url
+
+- https://base-sepolia-gateway-worker.ens-cf.workers.dev/{sender}/{data}.json
 
 ## Testing gateway
 

--- a/op-verifier/README.md
+++ b/op-verifier/README.md
@@ -29,3 +29,35 @@ hardhat test --network opDevnetL1
 ```
 
 The tests will require small modifications to work on public testnets; specifically, contract addresses are currently fetched from `http://localhost:8080/addresses.json`; this will need to be made conditional on the network being used.
+
+## Deployed addresses
+
+### Optimism
+
+#### L1
+
+- OPVerifier = [0x0e8DA38565915B7e74e2d78F80ba1BF815F34116](https://sepolia.etherscan.io/address/0x0e8DA38565915B7e74e2d78F80ba1BF815F34116#code)
+- TestL1 = [0x00198c6c94522A81698190ADF411641995Eb180c](https://sepolia.etherscan.io/address/0x00198c6c94522A81698190ADF411641995Eb180c#code
+)
+#### L2
+
+- TestL2 = [0x94fbCE7ca1a0152cfC99F90f4421d31cf356c896](https://sepolia-optimism.etherscan.io/address/0x94fbCE7ca1a0152cfC99F90f4421d31cf356c896)
+
+#### Gateway url
+
+- https://op-sepolia-gateway-worker.ens-cf.workers.dev/{sender}/{data}.json
+
+### Base
+
+#### L1
+
+#### L2
+
+- TestL2 = [0x94fbCE7ca1a0152cfC99F90f4421d31cf356c896](https://sepolia.basescan.org/address/0x94fbCE7ca1a0152cfC99F90f4421d31cf356c896#code)
+
+
+## Testing gateway
+
+```
+TARGET_ADDRESS=$TEST_L1_ADDRESS PROVIDER_URL=$L1_PROVIDER_URL npx hardhat run ../l1-verifier/scripts/remote.ts --network sepolia
+```

--- a/op-verifier/arguments.js
+++ b/op-verifier/arguments.js
@@ -1,6 +1,6 @@
 module.exports = [
   [
-    'https://op-sepolia-gateway-worker.ens-cf.workers.dev/{sender}/{data}.json'
+    'https://base-sepolia-gateway-worker.ens-cf.workers.dev/{sender}/{data}.json'
   ],
-  '0x90E9c4f8a994a250F6aEfd61CAFb4F2e895D458F'
+  '0x84457ca9D0163FbC4bbfe4Dfbb20ba46e48DF254'
 ];

--- a/op-verifier/arguments.js
+++ b/op-verifier/arguments.js
@@ -1,0 +1,6 @@
+module.exports = [
+  [
+    'https://op-sepolia-gateway-worker.ens-cf.workers.dev/{sender}/{data}.json'
+  ],
+  '0x90E9c4f8a994a250F6aEfd61CAFb4F2e895D458F'
+];

--- a/op-verifier/deploy_l1/00_op_verifier.ts
+++ b/op-verifier/deploy_l1/00_op_verifier.ts
@@ -5,10 +5,14 @@ import fs from 'fs';
 const GATEWAY_URLS = {
   'opDevnetL1':'http://localhost:8080/{sender}/{data}.json',
   'goerli':'https://op-gateway-worker.ens-cf.workers.dev/{sender}/{data}.json',
+  'sepolia':'https://op-sepolia-gateway-worker.ens-cf.workers.dev/{sender}/{data}.json',
+  'sepoliaforbase':'https://base-sepolia-gateway-worker.ens-cf.workers.dev/{sender}/{data}.json',
 }
 
 const L2_OUTPUT_ORACLE_ADDRESSES = {
-  'goerli': '0xE6Dfba0953616Bacab0c9A8ecb3a9BBa77FC15c0'
+  'goerli': '0xE6Dfba0953616Bacab0c9A8ecb3a9BBa77FC15c0',
+  'sepolia': '0x90E9c4f8a994a250F6aEfd61CAFb4F2e895D458F',
+  'sepoliaforbase': '0x84457ca9D0163FbC4bbfe4Dfbb20ba46e48DF254',
 }
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
@@ -20,12 +24,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     const opAddresses = await (await fetch("http://localhost:8080/addresses.json")).json();
     L2_OUTPUT_ORACLE_ADDRESS = opAddresses.L2OutputOracleProxy
   }else{
+    GATEWAY_URL = GATEWAY_URLS[network.name]
     L2_OUTPUT_ORACLE_ADDRESS = L2_OUTPUT_ORACLE_ADDRESSES[network.name]
   }
   console.log('OPVerifier', [[GATEWAY_URL], L2_OUTPUT_ORACLE_ADDRESS])
   await deploy('OPVerifier', {
     from: deployer,
-    args: [[GATEWAY_URLS[network.name]], L2_OUTPUT_ORACLE_ADDRESS],
+    args: [[GATEWAY_URL], L2_OUTPUT_ORACLE_ADDRESS],
     log: true,
   });
 };

--- a/op-verifier/deploy_l1/10_testl1.ts
+++ b/op-verifier/deploy_l1/10_testl1.ts
@@ -10,7 +10,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const OPVerifier = await deployments.get('OPVerifier');
   const TestL2 = await hre.companionNetworks['l2'].deployments.get('TestL2');
-
+  console.log([OPVerifier.address, TestL2.address])
   await deploy('TestL1', {
     from: deployer,
     args: [OPVerifier.address, TestL2.address],

--- a/op-verifier/deploy_l1/10_testl1.ts
+++ b/op-verifier/deploy_l1/10_testl1.ts
@@ -10,7 +10,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const OPVerifier = await deployments.get('OPVerifier');
   const TestL2 = await hre.companionNetworks['l2'].deployments.get('TestL2');
-  console.log([OPVerifier.address, TestL2.address])
+  console.log(`TestL1 is deployed with OPVerifier.address ${OPVerifier.address} and TestL2.address ${TestL2.address} as argments`)
   await deploy('TestL1', {
     from: deployer,
     args: [OPVerifier.address, TestL2.address],

--- a/op-verifier/deploy_l2/01_testl2.ts
+++ b/op-verifier/deploy_l2/01_testl2.ts
@@ -6,7 +6,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {deploy} = deployments;
 
   const {deployer} = await getNamedAccounts();
-  console.log(network)
+
   await deploy('TestL2', {
     from: deployer,
     args: [],

--- a/op-verifier/deploy_l2/01_testl2.ts
+++ b/op-verifier/deploy_l2/01_testl2.ts
@@ -2,11 +2,11 @@ import {HardhatRuntimeEnvironment} from 'hardhat/types';
 import {DeployFunction} from 'hardhat-deploy/types';
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const {deployments, getNamedAccounts} = hre;
+  const {deployments, getNamedAccounts, network} = hre;
   const {deploy} = deployments;
 
   const {deployer} = await getNamedAccounts();
-
+  console.log(network)
   await deploy('TestL2', {
     from: deployer,
     args: [],

--- a/op-verifier/hardhat.config.ts
+++ b/op-verifier/hardhat.config.ts
@@ -36,12 +36,42 @@ const config: HardhatUserConfig = {
       url: "https://goerli.optimism.io",
       accounts: [DEPLOYER_PRIVATE_KEY],
       deploy: [ "deploy_l2/" ],
-    }
+    },
+    sepolia: {
+      url: L1_PROVIDER_URL,
+      accounts: [DEPLOYER_PRIVATE_KEY],
+      deploy: [ "deploy_l1/" ],
+      companionNetworks: {
+        l2: "optimismSepolia",
+      },
+    },
+    sepoliaforbase: {
+      url: L1_PROVIDER_URL,
+      accounts: [DEPLOYER_PRIVATE_KEY],
+      deploy: [ "deploy_l1/" ],
+      companionNetworks: {
+        l2: "baseSepolia",
+      },
+    },
+    optimismSepolia: {
+      url: "https://sepolia.optimism.io",
+      accounts: [DEPLOYER_PRIVATE_KEY],
+      deploy: [ "deploy_l2/" ],
+    },
+    baseSepolia: {
+      url: "https://sepolia.base.org",
+      accounts: [DEPLOYER_PRIVATE_KEY],
+      deploy: [ "deploy_l2/" ],
+    },
   },
   etherscan: {
     apiKey: {
         goerli: L1_ETHERSCAN_API_KEY,
-        optimismGoerli: L2_ETHERSCAN_API_KEY
+        sepolia: L1_ETHERSCAN_API_KEY,
+        optimismGoerli: L2_ETHERSCAN_API_KEY,
+        baseGoerli: L2_ETHERSCAN_API_KEY,
+        optimismSepolia: L2_ETHERSCAN_API_KEY,
+        baseSepolia: L2_ETHERSCAN_API_KEY,
     },
     customChains: [
       {
@@ -51,7 +81,23 @@ const config: HardhatUserConfig = {
             apiURL: "https://api-goerli-optimism.etherscan.io/api",
             browserURL: "https://goerli-optimism.etherscan.io"
         }
-      }
+      },
+      {
+        network: "optimismSepolia",
+        chainId: 11155420,
+        urls: {
+            apiURL: "https://api-sepolia-optimism.etherscan.io/api",
+            browserURL: "https://sepolia-optimism.etherscan.io"
+        }
+      },
+      {
+        network: "baseSepolia",
+        chainId: 84532,
+        urls: {
+          apiURL: "https://api-sepolia.basescan.org/api",
+          browserURL: "https://sepolia.basescan.org"
+        }
+      },
     ]
   },
   namedAccounts: {


### PR DESCRIPTION
NOTE: ENS related contract deployment detail will be added as two separate PRs  (l2 resolvers and reverse registrars will be under `@ensdomains/ens-contracts` and l1 resolvers will be on this repo)