### PR TITLE
Initial implementation of multi-target CCIP read

### DIFF
--- a/evm-verifier/contracts/EVMFetchTarget.sol
+++ b/evm-verifier/contracts/EVMFetchTarget.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.17;
 
 import { IEVMVerifier } from './IEVMVerifier.sol';
+import { IEVMGateway } from './IEVMGateway.sol';
 import { Address } from '@openzeppelin/contracts/utils/Address.sol';
 
 /**
@@ -11,20 +12,69 @@ import { Address } from '@openzeppelin/contracts/utils/Address.sol';
 abstract contract EVMFetchTarget {
     using Address for address;
 
+    error TargetProofMismatch(uint256 actual, uint256 expected);
     error ResponseLengthMismatch(uint256 actual, uint256 expected);
+    error TooManyReturnValues(uint256 max);
+
+    uint256 constant MAX_RETURN_VALUES = 32;
 
     /**
      * @dev Internal callback function invoked by CCIP-Read in response to a `getStorageSlots` request.
      */
     function getStorageSlotsCallback(bytes calldata response, bytes calldata extradata) external {
-        bytes memory proof = abi.decode(response, (bytes));
-        (IEVMVerifier verifier, address addr, bytes32[] memory commands, bytes[] memory constants, bytes4 callback, bytes memory callbackData) =
-            abi.decode(extradata, (IEVMVerifier, address, bytes32[], bytes[], bytes4, bytes));
-        bytes[] memory values = verifier.getStorageValues(addr, commands, constants, proof);
-        if(values.length != commands.length) {
-            revert ResponseLengthMismatch(values.length, commands.length);
+
+        //Decode proofs from the response
+        (bytes[] memory proofs) = abi.decode(response, (bytes[]));
+
+        //Decode the extradata
+        (IEVMVerifier verifier, IEVMGateway.EVMTargetRequest[] memory tRequests, bytes4 callback, bytes memory callbackData) =
+            abi.decode(extradata, (IEVMVerifier, IEVMGateway.EVMTargetRequest[], bytes4, bytes));
+
+        //We proove all returned data on a per target basis
+        if(tRequests.length != proofs.length) {
+            revert TargetProofMismatch(tRequests.length, proofs.length);
         }
-        bytes memory ret = address(this).functionCall(abi.encodeWithSelector(callback, values, callbackData));
+
+        bytes[] memory returnValues = new bytes[](MAX_RETURN_VALUES);
+    
+        uint k = 0;
+
+        for (uint i = 0; i < tRequests.length; i++) {
+            
+            IEVMGateway.EVMTargetRequest memory tRequest = tRequests[i];
+
+            address targetToUse = tRequest.target;
+
+            {
+                uint160 targetAsInt = uint160(bytes20(tRequest.target));
+
+                if (targetAsInt <= 256) {
+
+                    targetToUse = abi.decode(returnValues[0], (address));
+                }
+            }
+
+            bytes[] memory values = verifier.getStorageValues(targetToUse, tRequest.commands, tRequest.constants, proofs[i]);
+            
+            if(values.length != tRequest.commands.length) {
+                revert ResponseLengthMismatch(values.length, tRequest.commands.length);
+            }
+
+            for (uint j = 0; j < values.length; j++) {
+                returnValues[k] = values[j];
+                k++;
+            }
+        }
+
+        assembly {
+            mstore(returnValues, k) // Increment returnValues array length
+        }
+        if(k > MAX_RETURN_VALUES) {
+            revert TooManyReturnValues(MAX_RETURN_VALUES);
+        }
+
+        bytes memory ret = address(this).functionCall(abi.encodeWithSelector(callback, returnValues, callbackData));
+
         assembly {
             return(add(ret, 32), mload(ret))
         }

--- a/evm-verifier/contracts/EVMFetcher.sol
+++ b/evm-verifier/contracts/EVMFetcher.sol
@@ -3,12 +3,10 @@ pragma solidity ^0.8.17;
 
 import { IEVMVerifier } from './IEVMVerifier.sol';
 import { EVMFetchTarget } from './EVMFetchTarget.sol';
+import { IEVMGateway } from './IEVMGateway.sol';
 import { Address } from '@openzeppelin/contracts/utils/Address.sol';
 
-interface IEVMGateway {
-    function getStorageSlots(address addr, bytes32[] memory commands, bytes[] memory constants) external pure returns(bytes memory witness);
-}
-
+uint8 constant FLAG_STATIC = 0x00;
 uint8 constant FLAG_DYNAMIC = 0x01;
 uint8 constant OP_CONSTANT = 0x00;
 uint8 constant OP_BACKREF = 0x20;
@@ -19,70 +17,121 @@ uint8 constant OP_END = 0xff;
  *      See l1-verifier/test/TestL1.sol for example usage.
  */
 library EVMFetcher {
+    uint256 constant MAX_TARGETS = 32;
     uint256 constant MAX_COMMANDS = 32;
     uint256 constant MAX_CONSTANTS = 32; // Must not be greater than 32
 
     using Address for address;
 
     error TooManyCommands(uint256 max);
+    error TooManyTargets(uint256 max);
     error CommandTooLong();
     error InvalidReference(uint256 value, uint256 max);
     error OffchainLookup(address sender, string[] urls, bytes callData, bytes4 callbackFunction, bytes extraData);
 
     struct EVMFetchRequest {
         IEVMVerifier verifier;
-        address target;
-        bytes32[] commands;
-        uint256 operationIdx;
-        bytes[] constants;
+        IEVMGateway.EVMTargetRequest[] tRequests;
     }
 
     /**
-     * @dev Creates a request to fetch the value of multiple storage slots from a contract via CCIP-Read, possibly from
-     *      another chain.
-     *      Supports dynamic length values and slot numbers derived from other retrieved values.
+     * @dev Creates a new EVMTargetRequest
+     *      Internal helper function for DRY code
+     * @param request The request object being operated on.
+     * @param target The new target address
+     */
+    function addNewTargetRequest(EVMFetchRequest memory request, address target) internal pure {
+
+        IEVMGateway.EVMTargetRequest[] memory targetRequests = request.tRequests;
+        uint256 targetCount = targetRequests.length;
+
+        bytes32[] memory commands = new bytes32[](MAX_COMMANDS);
+        bytes[] memory constants = new bytes[](MAX_CONSTANTS);
+        assembly {
+            mstore(targetRequests, add(targetCount, 1)) //Set the array length to 1 (for the initial target)
+            mstore(commands, 0) // Set current array length to 0
+            mstore(constants, 0)
+        }        
+
+        if(targetRequests.length > MAX_TARGETS) {
+            revert TooManyTargets(MAX_TARGETS);
+        }
+
+        targetRequests[targetCount] = IEVMGateway.EVMTargetRequest(target, commands, constants, 0);
+    }
+
+    /**
+     * @dev Creates a request to fetch the value of multiple storage slots from one or more target contracts
+     * via CCIP-Read, possibly from another chain.
+     * Supports dynamic length values and slot numbers derived from other retrieved values.
      * @param verifier An instance of a verifier contract that can provide and verify the storage slot information.
      * @param target The address of the contract to fetch storage proofs for.
      */
     function newFetchRequest(IEVMVerifier verifier, address target) internal pure returns (EVMFetchRequest memory) {
-        bytes32[] memory commands = new bytes32[](MAX_COMMANDS);
-        bytes[] memory constants = new bytes[](MAX_CONSTANTS);
+        
+        //Reserve the space
+        IEVMGateway.EVMTargetRequest[] memory targetRequests = new IEVMGateway.EVMTargetRequest[](MAX_TARGETS);
+
         assembly {
-            mstore(commands, 0) // Set current array length to 0
-            mstore(constants, 0)
-        }        
-        return EVMFetchRequest(verifier, target, commands, 0, constants);
+            mstore(targetRequests, 0)
+        }       
+
+        //Create the base EVMFetchRequest
+        EVMFetchRequest memory request = EVMFetchRequest(verifier, targetRequests);
+
+        //Add a new IEVMGateway.EVMTargetRequest
+        addNewTargetRequest(request, target);
+
+        return request;
     }
 
     /**
-     * @dev Starts describing a new fetch request.
-     *      Paths specify a series of hashing operations to derive the final slot ID.
+     * @dev Initializes a new EVM command for fetching a data value from a target
+     *      Internal helper function for DRY code
+     * @param request The request object being operated on.
+     * @param baseSlot The base slot ID that forms the root of the path.
+     * @param flag The command flag specifying if the requested value is housed in a static or dynamic storage slot
+     */
+    function initNewCommand(EVMFetchRequest memory request, uint256 baseSlot, uint8 flag) internal pure {
+
+        uint256 targetIdx = request.tRequests.length - 1;
+        IEVMGateway.EVMTargetRequest memory tRequest = request.tRequests[targetIdx];
+        bytes32[] memory commands = tRequest.commands;
+        
+        uint256 commandIdx = commands.length;
+        if(commandIdx > 0 && tRequest.operationIdx < 32) {
+            // Terminate previous command
+            _addOperation(tRequest, OP_END);
+        }
+        assembly {
+            mstore(commands, add(commandIdx, 1)) // Increment command array length
+        }
+        if(commands.length > MAX_COMMANDS) {
+            revert TooManyCommands(MAX_COMMANDS);
+        }
+
+        tRequest.operationIdx = 0;
+        _addOperation(tRequest, flag);
+        _addOperation(tRequest, _addConstant(tRequest, abi.encode(baseSlot)));
+    }
+
+    /**
+     * @dev Initialize a command to fetch a data value from a single static storage slot
      *      See https://docs.soliditylang.org/en/v0.8.17/internals/layout_in_storage.html for details on how Solidity
      *      lays out storage variables.
      * @param request The request object being operated on.
      * @param baseSlot The base slot ID that forms the root of the path.
      */
     function getStatic(EVMFetchRequest memory request, uint256 baseSlot) internal pure returns (EVMFetchRequest memory) {
-        bytes32[] memory commands = request.commands;
-        uint256 commandIdx = commands.length;
-        if(commandIdx > 0 && request.operationIdx < 32) {
-            // Terminate previous command
-            _addOperation(request, OP_END);
-        }
-        assembly {
-            mstore(commands, add(commandIdx, 1)) // Increment command array length
-        }
-        if(request.commands.length > MAX_COMMANDS) {
-            revert TooManyCommands(MAX_COMMANDS);
-        }
-        request.operationIdx = 0;
-        _addOperation(request, 0);
-        _addOperation(request, _addConstant(request, abi.encode(baseSlot)));
+        
+        initNewCommand(request, baseSlot, FLAG_STATIC);
+
         return request;
     }
 
     /**
-     * @dev Starts describing a new fetch request.
+     * @dev Initialize a command to fetch a dynamic data value from multiple storage slots
+     *      subject to the Solidity storage rules
      *      Paths specify a series of hashing operations to derive the final slot ID.
      *      See https://docs.soliditylang.org/en/v0.8.17/internals/layout_in_storage.html for details on how Solidity
      *      lays out storage variables.
@@ -90,21 +139,9 @@ library EVMFetcher {
      * @param baseSlot The base slot ID that forms the root of the path.
      */
     function getDynamic(EVMFetchRequest memory request, uint256 baseSlot) internal pure returns (EVMFetchRequest memory) {
-        bytes32[] memory commands = request.commands;
-        uint256 commandIdx = commands.length;
-        if(commandIdx > 0 && request.operationIdx < 32) {
-            // Terminate previous command
-            _addOperation(request, OP_END);
-        }
-        assembly {
-            mstore(commands, add(commandIdx, 1)) // Increment command array length
-        }
-        if(request.commands.length > MAX_COMMANDS) {
-            revert TooManyCommands(MAX_COMMANDS);
-        }
-        request.operationIdx = 0;
-        _addOperation(request, FLAG_DYNAMIC);
-        _addOperation(request, _addConstant(request, abi.encode(baseSlot)));
+        
+        initNewCommand(request, baseSlot, FLAG_DYNAMIC);
+
         return request;
     }
 
@@ -114,10 +151,15 @@ library EVMFetcher {
      * @param el The element to add.
      */
     function element(EVMFetchRequest memory request, uint256 el) internal pure returns (EVMFetchRequest memory) {
-        if(request.operationIdx >= 32) {
+
+        uint256 targetIdx = request.tRequests.length - 1;
+        IEVMGateway.EVMTargetRequest memory tRequest = request.tRequests[targetIdx];
+        
+        if(tRequest.operationIdx >= 32) {
             revert CommandTooLong();
         }
-        _addOperation(request, _addConstant(request, abi.encode(el)));
+        _addOperation(tRequest, _addConstant(tRequest, abi.encode(el)));
+
         return request;
     }
 
@@ -127,10 +169,15 @@ library EVMFetcher {
      * @param el The element to add.
      */
     function element(EVMFetchRequest memory request, bytes32 el) internal pure returns (EVMFetchRequest memory) {
-        if(request.operationIdx >= 32) {
+
+        uint256 targetIdx = request.tRequests.length - 1;
+        IEVMGateway.EVMTargetRequest memory tRequest = request.tRequests[targetIdx];
+        
+        if(tRequest.operationIdx >= 32) {
             revert CommandTooLong();
         }
-        _addOperation(request, _addConstant(request, abi.encode(el)));
+        _addOperation(tRequest, _addConstant(tRequest, abi.encode(el)));
+
         return request;
     }
 
@@ -140,10 +187,14 @@ library EVMFetcher {
      * @param el The element to add.
      */
     function element(EVMFetchRequest memory request, address el) internal pure returns (EVMFetchRequest memory) {
-        if(request.operationIdx >= 32) {
+
+        uint256 targetIdx = request.tRequests.length - 1;
+        IEVMGateway.EVMTargetRequest memory tRequest = request.tRequests[targetIdx];
+        
+        if(tRequest.operationIdx >= 32) {
             revert CommandTooLong();
         }
-        _addOperation(request, _addConstant(request, abi.encode(el)));
+        _addOperation(tRequest, _addConstant(tRequest, abi.encode(el)));
         return request;
     }
 
@@ -153,10 +204,14 @@ library EVMFetcher {
      * @param el The element to add.
      */
     function element(EVMFetchRequest memory request, bytes memory el) internal pure returns (EVMFetchRequest memory) {
-        if(request.operationIdx >= 32) {
+
+        uint256 targetIdx = request.tRequests.length - 1;
+        IEVMGateway.EVMTargetRequest memory tRequest = request.tRequests[targetIdx];
+        
+        if(tRequest.operationIdx >= 32) {
             revert CommandTooLong();
         }
-        _addOperation(request, _addConstant(request, el));
+        _addOperation(tRequest, _addConstant(tRequest, el));
         return request;
     }
 
@@ -166,10 +221,14 @@ library EVMFetcher {
      * @param el The element to add.
      */
     function element(EVMFetchRequest memory request, string memory el) internal pure returns (EVMFetchRequest memory) {
-        if(request.operationIdx >= 32) {
+
+        uint256 targetIdx = request.tRequests.length - 1;
+        IEVMGateway.EVMTargetRequest memory tRequest = request.tRequests[targetIdx];
+        
+        if(tRequest.operationIdx >= 32) {
             revert CommandTooLong();
         }
-        _addOperation(request, _addConstant(request, bytes(el)));
+        _addOperation(tRequest, _addConstant(tRequest, bytes(el)));
         return request;
     }
 
@@ -179,13 +238,58 @@ library EVMFetcher {
      * @param idx The index of the previous fetch request, starting at 0.
      */
     function ref(EVMFetchRequest memory request, uint8 idx) internal pure returns (EVMFetchRequest memory) {
-        if(request.operationIdx >= 32) {
+
+        uint256 targetIdx = request.tRequests.length - 1;
+        IEVMGateway.EVMTargetRequest memory tRequest = request.tRequests[targetIdx];
+
+        if(tRequest.operationIdx >= 32) {
             revert CommandTooLong();
         }
-        if(idx > request.commands.length || idx > 31) {
-            revert InvalidReference(idx, request.commands.length);
+        if(idx > tRequest.commands.length || idx > 31) {
+            revert InvalidReference(idx, tRequest.commands.length);
         }
-        _addOperation(request, OP_BACKREF | idx);
+        _addOperation(tRequest, OP_BACKREF | idx);
+        return request;
+    }
+
+    /**
+     * @dev Sets the target contract address from which to fetch future requested values
+     * @param request The request object being operated on.
+     * @param target The target contract address
+     */
+    function setTarget(EVMFetchRequest memory request, address target) internal pure returns (EVMFetchRequest memory) {
+
+        IEVMGateway.EVMTargetRequest[] memory tRequests = request.tRequests;
+
+        uint256 targetCount = tRequests.length;
+        uint256 targetIdx = targetCount - 1;
+
+        //Close off the last command for the previous IEVMGateway.EVMTargetRequest
+        IEVMGateway.EVMTargetRequest memory tRequest = request.tRequests[targetIdx];
+        bytes32[] memory commands = tRequest.commands;
+
+        if(commands.length > 0 && tRequest.operationIdx < 32) {
+            // Terminate last command
+            _addOperation(tRequest, OP_END);
+        }
+        
+        //Add a new IEVMGateway.EVMTargetRequest
+        addNewTargetRequest(request, target);
+
+        return request;
+    }
+
+    /**
+     * @dev Sets the target contract address from which to fetch future requested values
+     * to an address returned as a value from a previous indexed request
+     * @param request The request object being operated on.
+     * @param idx The index of the value requested that contains an address to target
+     */
+    function setTargetRef(EVMFetchRequest memory request, uint8 idx) internal pure returns (EVMFetchRequest memory) {
+
+        address targetAddress = address(uint160(bytes20(bytes1(idx)) >> (152)));
+        setTarget(request, targetAddress);
+
         return request;
     }
 
@@ -199,30 +303,41 @@ library EVMFetcher {
      * @param callbackData Extra data to supply to the callback.
      */
     function fetch(EVMFetchRequest memory request, bytes4 callbackId, bytes memory callbackData) internal view {
-        if(request.commands.length > 0 && request.operationIdx < 32) {
+
+        uint256 targetIdx = request.tRequests.length - 1;
+        IEVMGateway.EVMTargetRequest memory tRequest = request.tRequests[targetIdx];
+
+        bytes[] memory constants = tRequest.constants;
+
+        if(tRequest.commands.length > 0 && tRequest.operationIdx < 32) {
             // Terminate last command
-            _addOperation(request, OP_END);
+            _addOperation(tRequest, OP_END);
         }
+        
         revert OffchainLookup(
             address(this),
             request.verifier.gatewayURLs(),
-            abi.encodeCall(IEVMGateway.getStorageSlots, (request.target, request.commands, request.constants)),
+            abi.encodeCall(IEVMGateway.getStorageSlots, request.tRequests),
             EVMFetchTarget.getStorageSlotsCallback.selector,
-            abi.encode(request.verifier, request.target, request.commands, request.constants, callbackId, callbackData)
+            abi.encode(request.verifier, request.tRequests, callbackId, callbackData)
         );
     }
 
-    function _addConstant(EVMFetchRequest memory request, bytes memory value) private pure returns(uint8 idx) {
-        bytes[] memory constants = request.constants;
+    function _addConstant(IEVMGateway.EVMTargetRequest memory tRequest, bytes memory value) private pure returns(uint8 idx) {
+
+        bytes[] memory constants = tRequest.constants;
+
         idx = uint8(constants.length);
+
         assembly {
             mstore(constants, add(idx, 1)) // Increment constant array length
         }
         constants[idx] = value;
     }
 
-    function _addOperation(EVMFetchRequest memory request, uint8 op) private pure {
-        uint256 commandIdx = request.commands.length - 1;
-        request.commands[commandIdx] = request.commands[commandIdx] | (bytes32(bytes1(op)) >> (8 * request.operationIdx++));
+    function _addOperation(IEVMGateway.EVMTargetRequest memory tRequest, uint8 op) private pure {
+
+        uint256 commandIdx = tRequest.commands.length - 1;
+        tRequest.commands[commandIdx] = tRequest.commands[commandIdx] | (bytes32(bytes1(op)) >> (8 * tRequest.operationIdx++));
     }
 }

--- a/evm-verifier/contracts/IEVMGateway.sol
+++ b/evm-verifier/contracts/IEVMGateway.sol
@@ -1,0 +1,14 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+interface IEVMGateway {
+
+    struct EVMTargetRequest {
+        address target;
+        bytes32[] commands;
+        bytes[] constants;
+        uint256 operationIdx;
+    }
+
+    function getStorageSlots(EVMTargetRequest[] memory tRequests) external pure returns(bytes memory witness);
+}

--- a/l1-gateway/package.json
+++ b/l1-gateway/package.json
@@ -58,7 +58,6 @@
   "dependencies": {
     "@chainlink/ccip-read-server": "^0.2.1",
     "@commander-js/extra-typings": "^11.0.0",
-    "@ensdomains/evm-gateway": "^0.1.0",
     "@ethereumjs/block": "^5.0.0",
     "@nomicfoundation/ethereumjs-block": "^5.0.2",
     "commander": "^11.0.0",

--- a/l1-gateway/src/L1ProofService.ts
+++ b/l1-gateway/src/L1ProofService.ts
@@ -5,7 +5,7 @@ import {
   type JsonRpcProvider,
 } from 'ethers';
 
-import { EVMProofHelper, type IProofService } from '@ensdomains/evm-gateway';
+import { EVMProofHelper, type IProofService } from '../../evm-gateway';
 import { Block, type JsonRpcBlock } from '@ethereumjs/block';
 
 type RlpObject = Uint8Array | Array<RlpObject>;

--- a/l1-gateway/src/index.ts
+++ b/l1-gateway/src/index.ts
@@ -1,4 +1,5 @@
-import { EVMGateway } from '@ensdomains/evm-gateway';
+import { EVMGateway } from '../../evm-gateway';
+
 import { JsonRpcProvider } from 'ethers';
 import { L1ProofService, type L1ProvableBlock } from './L1ProofService.js';
 

--- a/l1-gateway/src/server.ts
+++ b/l1-gateway/src/server.ts
@@ -1,6 +1,6 @@
 import { Server } from '@chainlink/ccip-read-server';
 import { Command } from '@commander-js/extra-typings';
-import { EVMGateway } from '@ensdomains/evm-gateway';
+import { EVMGateway } from '../../evm-gateway';
 import { ethers } from 'ethers';
 import { L1ProofService } from './L1ProofService.js';
 

--- a/l1-verifier/contracts/test/TestL1.sol
+++ b/l1-verifier/contracts/test/TestL1.sol
@@ -10,10 +10,12 @@ contract TestL1 is EVMFetchTarget {
 
     IEVMVerifier verifier;                  // Slot 0
     address target;
+    address target2;
 
-    constructor(IEVMVerifier _verifier, address _target) {
+    constructor(IEVMVerifier _verifier, address _target, address _target2) {
         verifier = _verifier;
         target = _target;
+        target2 = _target2;
     }
 
     function getLatest() public view returns(uint256) {
@@ -26,9 +28,47 @@ contract TestL1 is EVMFetchTarget {
         return abi.decode(values[0], (uint256));
     }
 
+    function getSecondAddress() public view returns(address) {
+        EVMFetcher.newFetchRequest(verifier, target)
+            .getStatic(1)
+            .fetch(this.getSecondAddressCallback.selector, "");
+    }
+
+    function getSecondAddressCallback(bytes[] memory values, bytes memory) public pure returns(address) {
+        return abi.decode(values[0], (address));
+    }
+
+    function getValueFromSecondContract() public view returns(address) {
+        EVMFetcher.newFetchRequest(verifier, target)
+            .getStatic(1)
+                .setTargetRef(0)
+            .getStatic(1)   
+            .fetch(this.getValueFromSecondContractCallback.selector, "");
+    }
+
+    function getValueFromSecondContractCallback(bytes[] memory values, bytes memory) public pure returns(address) {
+        return abi.decode(values[1], (address));
+    }
+
+    function getLatestFromTwoTargets() public view returns(uint256) {
+
+        EVMFetcher.newFetchRequest(verifier, target)
+            .getStatic(0)
+            .setTarget(target2)
+            .getStatic(0)
+            .fetch(this.getLatestFromTwoTargetsCallback.selector, "");
+    }
+
+    function getLatestFromTwoTargetsCallback(bytes[] memory values, bytes memory) public pure returns(uint256) {
+        uint256 l1 = abi.decode(values[0], (uint256));
+        uint256 l2 = abi.decode(values[1], (uint256));
+
+        return l1 + l2;
+    }
+
     function getName() public view returns(string memory) {
         EVMFetcher.newFetchRequest(verifier, target)
-            .getDynamic(1)
+            .getDynamic(2)
             .fetch(this.getNameCallback.selector, "");
     }
 
@@ -38,7 +78,7 @@ contract TestL1 is EVMFetchTarget {
 
     function getHighscorer(uint256 idx) public view returns(string memory) {
         EVMFetcher.newFetchRequest(verifier, target)
-            .getDynamic(3)
+            .getDynamic(4)
                 .element(idx)
             .fetch(this.getHighscorerCallback.selector, "");
     }
@@ -50,7 +90,7 @@ contract TestL1 is EVMFetchTarget {
     function getLatestHighscore() public view returns(uint256) {
         EVMFetcher.newFetchRequest(verifier, target)
             .getStatic(0)
-            .getStatic(2)
+            .getStatic(3)
                 .ref(0)
             .fetch(this.getLatestHighscoreCallback.selector, "");
     }
@@ -62,7 +102,7 @@ contract TestL1 is EVMFetchTarget {
     function getLatestHighscorer() public view returns(string memory) {
         EVMFetcher.newFetchRequest(verifier, target)
             .getStatic(0)
-            .getDynamic(3)
+            .getDynamic(4)
                 .ref(0)
             .fetch(this.getLatestHighscorerCallback.selector, "");
     }
@@ -73,7 +113,7 @@ contract TestL1 is EVMFetchTarget {
 
     function getNickname(string memory _name) public view returns(string memory) {
         EVMFetcher.newFetchRequest(verifier, target)
-            .getDynamic(4)
+            .getDynamic(5)
                 .element(_name)
             .fetch(this.getNicknameCallback.selector, "");
     }
@@ -84,8 +124,8 @@ contract TestL1 is EVMFetchTarget {
 
     function getPrimaryNickname() public view returns(string memory) {
         EVMFetcher.newFetchRequest(verifier, target)
-            .getDynamic(1)
-            .getDynamic(4)
+            .getDynamic(2)
+            .getDynamic(5)
                 .ref(0)
             .fetch(this.getPrimaryNicknameCallback.selector, "");
     }
@@ -96,7 +136,7 @@ contract TestL1 is EVMFetchTarget {
 
     function getZero() public view returns(uint256) {
         EVMFetcher.newFetchRequest(verifier, target)
-            .getStatic(5)
+            .getStatic(6)
             .fetch(this.getZeroCallback.selector, "");
     }
 
@@ -106,8 +146,8 @@ contract TestL1 is EVMFetchTarget {
 
     function getZeroIndex() public view returns(uint256) {
         EVMFetcher.newFetchRequest(verifier, target)
-            .getStatic(5)
-            .getStatic(2)
+            .getStatic(6)
+            .getStatic(3)
                 .ref(0)
             .fetch(this.getZeroIndexCallback.selector, "");
     }

--- a/l1-verifier/contracts/test/TestL2.sol
+++ b/l1-verifier/contracts/test/TestL2.sol
@@ -3,14 +3,16 @@ pragma solidity ^0.8.17;
 
 contract TestL2 {
     uint256 latest;                         // Slot 0
-    string name;                            // Slot 1
-    mapping(uint256=>uint256) highscores;   // Slot 2
-    mapping(uint256=>string) highscorers;   // Slot 3
-    mapping(string=>string) realnames;      // Slot 4
-    uint256 zero;                           // Slot 5
+    address secondAddress;                  // Slot 1
+    string name;                            // Slot 2
+    mapping(uint256=>uint256) highscores;   // Slot 3
+    mapping(uint256=>string) highscorers;   // Slot 4
+    mapping(string=>string) realnames;      // Slot 5
+    uint256 zero;                           // Slot 6
 
-    constructor() {
-        latest = 42;
+    constructor(uint256 _latestNumber, address _secondAddress) {
+        latest = _latestNumber;
+        secondAddress = _secondAddress;
         name = "Satoshi";
         highscores[0] = 1;
         highscores[latest] = 12345;


### PR DESCRIPTION
This is my initial implementation of multi-target CCIP read.
I've had a play with a few APIs/architectures and settled on this one.

The crux new API additions being: 

- `setTarget` which allows you to target a new contract for the value lookups that follow
- `setTargetRef` which allows you to reference a value returned from a previous target value lookup. It is a naive API in that it assumes that the value returned and referenced is a valid 20 (padded to 32) byte address.

Added tests to demonstrate functionality in the context of two contracts deployed on L1.

Open to feedback, suggestions, and discussion.