### PR TITLE
Fix `bun` build issues & Minor config improvements

### DIFF
--- a/arb-gateway/README.md
+++ b/arb-gateway/README.md
@@ -9,25 +9,24 @@ To get started, you need to have an RPC URL for both Ethereum Mainnet and Arbitr
 ## How to use arb-gateway locally via cloudflare dev env (aka wrangler)
 
 ```
-npm install -g bun
 cd arb-gateway
+npm install -g bun wrangler
 bun install
 touch .dev.vars
 ## set L1_PROVIDER_URL, L2_PROVIDER_URL, L2_ROLLUP
-yarn dev
+bun run dev
 ```
 
 ## How to deploy arb-gateway to cloudflare
 
 ```
 cd arb-gateway
-npm install -g wrangler
-wrngler login
-
+npm install -g bun wrangler
+wrangler login
 wrangler secret put L1_PROVIDER_URL
 wrangler secret put L2_PROVIDER_URL
 wrangler secret put L2_ROLLUP
-yarn deploy
+bun run deploy
 ```
 
 ## How to test
@@ -39,6 +38,5 @@ yarn deploy
 5. Navigate to the Gateway directory using `cd ./arb-gateway`.
 6. Start the Gateway by running `bun run start -u http://127.0.0.1:8545/ -v http://127.0.0.1:8547/ -p 8089`.
 7. Open another Terminal Tab and navigate to the verifier directory using `cd ./arb-verifier/`.
-8. Deploy contracts to the node using the command ` npx hardhat --network arbDevnetL2 deploy && npx hardhat --network arbDevnetL1 deploy `.
+8. Deploy contracts to the node using the command `npx hardhat --network arbDevnetL2 deploy && npx hardhat --network arbDevnetL1 deploy`.
 9. Run the test using the command `bun run test`.
-

--- a/arb-gateway/wrangler.toml
+++ b/arb-gateway/wrangler.toml
@@ -8,6 +8,6 @@ compatibility_date = "2023-10-13"
 port = 8080
 
 [build]
-command = "yarn build"
+command = "bun run build"
 
 [vars]

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+# Only run 1 script at a time to prevent race conditions (see https://github.com/ensdomains/evmgateway/issues/31) 
+install.concurrentScripts = 1

--- a/l1-gateway/README.md
+++ b/l1-gateway/README.md
@@ -12,29 +12,29 @@ or historic values for storage variables of any contract.
 ## How to use l1-gateway locally via cloudflare dev env (aka wrangler)
 
 ```
-npm install -g bun
 cd l1-gateway
+npm install -g bun wrangler
 bun install
 touch .dev.vars
 ## set WORKER_PROVIDER_URL
-yarn dev
+bun run dev
 ```
 
 ## How to deploy l1-gateway to cloudflare
 
 ```
 cd l1-gateway
-npm install -g wrangler
-wrngler login
+npm install -g bun wrangler
+wrangler login
 wrangler secret put WORKER_PROVIDER_URL
-yarn deploy
+bun run deploy
 ```
 
 ## How to test
 
 ```
 cd ../l1-verifier l1-gateway
-PROVIDER_URL=$PROVIDER_URL TARGET_ADDRESS=$TARGET_ADDRESS yarn remote_test
+PROVIDER_URL=$PROVIDER_URL TARGET_ADDRESS=$TARGET_ADDRESS bun run remote_test
 ```
 
 ## Current deployments

--- a/l1-gateway/wrangler.toml
+++ b/l1-gateway/wrangler.toml
@@ -8,6 +8,6 @@ compatibility_date = "2023-10-13"
 port = 8080
 
 [build]
-command = "yarn build"
+command = "bun run build"
 
 [vars]

--- a/op-gateway/README.md
+++ b/op-gateway/README.md
@@ -7,32 +7,32 @@ For a detailed readme and usage instructions, see the [monorepo readme](https://
 ## How to use op-gateway locally via cloudflare dev env (aka wrangler)
 
 ```
-npm install -g bun
 cd op-gateway
+npm install -g bun wrangler
 bun install
 touch .dev.vars
 ## set L1_PROVIDER_URL, L2_PROVIDER_URL, L2_OUTPUT_ORACLE, DELAY=5
-yarn dev
+bun run dev
 ```
 
 ## How to deploy op-gateway to cloudflare
 
 ```
 cd op-gateway
-npm install -g wrangler
-wrngler login
+npm install -g bun wrangler
+wrangler login
 wrangler secret put L1_PROVIDER_URL
 wrangler secret put L2_PROVIDER_URL
 wrangler secret put L2_OUTPUT_ORACLE
 wrangler secret put DELAY
-yarn deploy
+bun run deploy
 ```
 
 ## How to test
 
 ```
 cd ../l1-verifier l1-gateway
-PROVIDER_URL=$PROVIDER_URL TARGET_ADDRESS=$TARGET_ADDRESS yarn remote_test
+PROVIDER_URL=$PROVIDER_URL TARGET_ADDRESS=$TARGET_ADDRESS bun run remote_test
 ```
 
 ## Current deployments

--- a/op-gateway/wrangler.toml
+++ b/op-gateway/wrangler.toml
@@ -8,6 +8,6 @@ compatibility_date = "2023-10-13"
 port = 8080
 
 [build]
-command = "yarn build"
+command = "bun run build"
 
 [vars]


### PR DESCRIPTION
Closes #31.

**Changes:**

* Adds `bunfig.toml` to disable concurrency when running the `prepare` script
* Use bun instead of yarn in `wrangler.toml` config ([which is supported](https://github.com/cloudflare/workers-sdk/issues/3941))
* Minor gateway README consistency improvements/typo fixes